### PR TITLE
Removing proxy and adding the default Demo baseURI

### DIFF
--- a/public/config_example.js
+++ b/public/config_example.js
@@ -25,14 +25,8 @@ config.IMPLICIT_SCOPES='signature';
 // DocuSign Identity server
 config.DS_IDP='https://account-d.docusign.com';
 
-// Your private API CORS proxies
-// Add additional entries for the demo and prod platforms that your 
-// users' accounts need
-config.DS_API_CORS_PROXIES= {
-    'https://na2.docusign.net' : 'https://xxxproxy.example.com',
-    'https://na3.docusign.net' : 'https://xxxproxy.example.com',
-    'https://demo.docusign.net': 'https://xxxproxy.example.com',
-}
+// Your DocuSign base URI 
+config.DS_BASE_URI = 'https://demo.docusign.net';
 
 // redirect authentication? 
 // true: the app redirects to the IdP

--- a/src/OAuthImplicit.js
+++ b/src/OAuthImplicit.js
@@ -106,7 +106,7 @@ class OAuthImplicit {
         // 
         // Need to select the right proxy for the API call
         // update the baseUri setting
-        let baseUri = config.DS_API_CORS_PROXIES[defaultAccount.base_uri];
+        let baseUri = config.DS_BASE_URI;
         if (!baseUri) {
             const msg = `Problem: no proxy for ${defaultAccount.base_uri}.`;
             log(msg);


### PR DESCRIPTION
Since we have CORS available to devs we do not need a proxy